### PR TITLE
add -m support

### DIFF
--- a/sftp-server.c
+++ b/sftp-server.c
@@ -77,7 +77,7 @@ static char *request_whitelist, *request_blacklist;
 /* Overwrite the permissions for uploaded file and directories */
 static int apply_default_perm = 0;
 static int force_default_perm = 0;
-static long file_default_perm, dir_default_perm;
+static long file_default_perm = 0, dir_default_perm = 0;
 
 /* portable attributes, etc. */
 typedef struct Stat Stat;

--- a/sftp-server.c
+++ b/sftp-server.c
@@ -74,7 +74,7 @@ static int readonly;
 /* Requests that are allowed/denied */
 static char *request_whitelist, *request_blacklist;
 
-/* Overwrite the file permissions for uploaded file and directories */
+/* Overwrite the permissions for uploaded file and directories */
 static int apply_default_perm = 0;
 static int force_default_perm = 0;
 static long file_default_perm, dir_default_perm;


### PR DESCRIPTION
add -m support, so when defining a user's `Match block`, if `-m` is specified, the files uploaded via sftp will be forced to applied the designated permissions.
Example:
```
Match User hlee
    ChrootDirectory /mnt/website-pro/wordpress-containers/site-id/web
    AllowTCPForwarding no
    X11Forwarding no
    ForceCommand internal-sftp -m f664d775
```
will force the files uploaded via sftp to have 664 permission and directories have 775 permission.

However, this permission can be bypassed by the client if the client is using `-P` option of `put` command. Further more, the client can also change the permission to whatever it wants by issuing a `chmod` command. If we want to prevent this, just put an exclamation mark (!) to the end of the mode. For example:
```
Match User hlee
    ChrootDirectory /mnt/website-pro/wordpress-containers/site-id/web
    AllowTCPForwarding no
    X11Forwarding no
    ForceCommand internal-sftp -m f664d775!
```
This configuration will force every file & directory to have the the specified permission. `put -P` or `chmod` will result in `Permission_denied` error